### PR TITLE
Add env vars to testing config to make tests pass

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,4 +36,8 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <php>
+        <env name="UP_CLOUD_USER_NAME" value="test" />
+        <env name="UP_CLOUD_PASSWORD" value="test" />
+    </php>
 </phpunit>


### PR DESCRIPTION
Tests are currently failing in ci and locally without explicitly setting certain environment variables, this PR adds those variables to the phpunit configuration. 
