### PR TITLE
Documentation typos

### DIFF
--- a/docs/basic-usage/configuring-your-first-server-type.md
+++ b/docs/basic-usage/configuring-your-first-server-type.md
@@ -15,7 +15,7 @@ use Spatie\DynamicServers\Models\Server;
 use Spatie\DynamicServers\Support\ServerTypes\ServerType;
 use \Spatie\DynamicServers\Support\DynamicServersManager;
 
-// typically, in `app/Providers/DynamicServerProvider
+// typically, in `app/Providers/DynamicServerProvider`
 
 /*
  * Let's set up the default server type  

--- a/docs/basic-usage/ensuring-a-number-of-servers.md
+++ b/docs/basic-usage/ensuring-a-number-of-servers.md
@@ -3,7 +3,7 @@ title: Ensuring a number of servers
 weight: 3
 ---
 
-You can use the `ensure($numberOfServerNeeded)` method to make sure that the given number of servers is available.
+You can use the `ensure($numberOfServerNeeded)` method to make sure that the given number of servers are available.
 
 ```php
 use Spatie\DynamicServers\Facades\DynamicServers;

--- a/docs/basic-usage/using-multiple-server-types.md
+++ b/docs/basic-usage/using-multiple-server-types.md
@@ -5,7 +5,7 @@ weight: 5
 
 When configuring the package, you probably will have [configured a default server type](/docs/laravel-dynamic-servers/v1/basic-usage/configuring-your-first-server-type).
 
-The package can handle multiple servers types. Here's how you can configure another server type using the `new` method.
+The package can handle multiple server types. Here's how you can configure another server type using the `new` method.
 
 ```php
 $serverType = ServerType::new('big')


### PR DESCRIPTION
As per request; a PR for 3 little typos I've noticed going over the documentation.