### PR TITLE
Delete pint.json

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,0 @@
-{
-    "exclude": [
-        "build"
-    ]
-}


### PR DESCRIPTION
Since pint [v1.1.3](https://github.com/laravel/pint/releases/tag/v1.1.3), the build folder is ignored by default. Since this project [requires](https://github.com/spatie/laravel-dynamic-servers/blob/main/composer.json#L32) v1.1.3, `pint.json` can be safely removed