### PR TITLE
Documentation fix: Replace $servers with DynamicServers facade

### DIFF
--- a/docs/basic-usage/ensuring-a-number-of-servers.md
+++ b/docs/basic-usage/ensuring-a-number-of-servers.md
@@ -61,6 +61,6 @@ Event::listen(function (LongWaitDetected $event) {
     
     $numberOfServersNeeded = round($waitTimeInMinutes / 10);
     
-    $servers->ensure($numberOfServersNeeded);
+    DynamicServers::ensure($numberOfServersNeeded);
 });
 ```


### PR DESCRIPTION
Replace `$servers` with `DynamicServers` facade because the variable is undefined.